### PR TITLE
TSX detaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.eggs
+build
+*egg-info
+__pycache__

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ The expected output include several `iso*.bed12` files, a set of assembled trans
 
 For IGIA assembled transcripts, isoF and isoA are the most reliable annotations. For details, please refer IGIA manuscript.
 
+Note: TSS and TES will use the annotated sites and the sites predicted by TGS data. See the `*.bed6` file for the data set used for transcript reconstruction.
+
 # Instructions for use
 
 To run IGIA with single-threaded mode, you can execute:

--- a/igia/skeleton.py
+++ b/igia/skeleton.py
@@ -62,7 +62,7 @@ def igia_parser():
     opt_group.add_argument("--time-out", type=int, dest="time_out", metavar="time_out", default=None,
                            help="Time out for complex loci")
     opt_group.add_argument("--paraclu-path", type=str, dest="paraclu_path", metavar="paraclu_path", default=None,
-                           help="Path to paraclu (for detecting TSS and TES from TGS data)")
+                           help="(recommend) Path to paraclu (for detecting TSS and TES from TGS data). If this parameter is set, TGS data will be also used to identify TXS to increase the coverage of gene annotations.")
     return parser
 
 def parse_args(args):


### PR DESCRIPTION
1. add gitignore
2. Exchange the order of using TXS in annotated reference and the farthest TGS to reduce the usage of the farthest TGS one. 
3. TGS data will be also used to identify TXS if setting paraclu-path parameter to increase the coverage of gene annotations.
4. Add note for the use of TSS and TES dataset